### PR TITLE
Fix Verrou and Verificarlo code generator python script

### DIFF
--- a/verificarlo_files/code_generator.py
+++ b/verificarlo_files/code_generator.py
@@ -33,9 +33,6 @@ class backend:
         _fetch_operations_codes: Take a backend path and go fetch each operations of each types to
                                  save their body in the "op_codes" dictionnary.
     """
-    name = ""
-    op_codes = {}
-
 
     def _fetch_op_body(self, lines, operation, type):
         """
@@ -103,6 +100,9 @@ class backend:
             name: String corresponding to the name of the backend.
             path: String corresponding to the path of the backend file.
         """
+        self.name = ""
+        self.op_codes = {}
+
         self.name = name
         self._fetch_operations_codes(path)
 

--- a/verrou_files/code_generator.py
+++ b/verrou_files/code_generator.py
@@ -39,9 +39,6 @@ class backend:
                                  operations of each types to save their body in
                                  the "op_codes" dictionnary.
     """
-    name = ""
-    op_codes = {}
-
 
     def _fetch_op_body(self, lines, operation, type):
         """
@@ -109,6 +106,9 @@ class backend:
             name: String corresponding to the name of the backend.
             path: String corresponding to the path of the backend file.
         """
+        self.name = ""
+        self.op_codes = {}
+
         self.name = name
         self._fetch_operations_codes(path)
 


### PR DESCRIPTION
name and op_codes in backend class are not shared between class instances anymore.
This was causing a problem where if the op_codes dict was modified in an instance of the backend class, every other op_codes in every other backend class where modified too.