### PR TITLE
fix: make jijna generator works without custom backend

### DIFF
--- a/verrou_files/templates/makefile.am.jinja
+++ b/verrou_files/templates/makefile.am.jinja
@@ -41,8 +41,9 @@ VERROU_SOURCES_COMMON = \
 	interflop_backends/backend_checkdenorm/interflop_checkdenorm.cxx
 
 
-ADDITIONAL_BACKEND_SOURCES = \
-    {% for backend_name in backend_names %}interflop_backends/backend_{{ backend_name }}/interflop_{{ backend_name }}.cxx {% endfor %}
+ADDITIONAL_BACKEND_SOURCES =
+    {% for backend_name in backend_names %}\ interflop_backends/backend_{{ backend_name }}/interflop_{{ backend_name }}.cxx
+{% endfor %}
 
 VERROU_SOURCES_COMMON += $(ADDITIONAL_BACKEND_SOURCES)
 


### PR DESCRIPTION
There is a little bug in the jinja template : the build can't be done without adding a custom backend. The line of the generator was edited to make it work with and without custom backends